### PR TITLE
🔧 chore(.gitignore): remove .env.local from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 .next
 package-lock.json
-!.env.local
 !.env.example

--- a/pages/work-single/[slug].jsx
+++ b/pages/work-single/[slug].jsx
@@ -2,6 +2,7 @@ import Layout from "@layouts/Layout";
 import { useFetchPortfolioBySlug } from "@hooks/useFetchPortfolios";
 import { formatDate } from "@src/utils";
 import Head from "next/head";
+const ASSETS_PATH = process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
 
 export const getServerSideProps = async (context) => {
   const slug = context.params.slug;
@@ -106,7 +107,7 @@ const WorkSingle = ({ slug }) => {
         <div className="container">
           <div className="row">
             <img
-              src={`/${image}`}
+              src={ASSETS_PATH + image}
               loading="lazy"
               decoding="async"
               className="img js-parallax"
@@ -138,7 +139,3 @@ const WorkSingle = ({ slug }) => {
   );
 };
 export default WorkSingle;
-
-
-
-

--- a/src/components/RenderPortfolios.js
+++ b/src/components/RenderPortfolios.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Link from "next/link";
 import { truncateText, truncateHtmlText } from "../utils";
-
+const ASSETS_PATH = process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
 /**
  * Renders the portfolios with loading and no data handling
  */
@@ -38,7 +38,7 @@ export const RenderPortfolios = ({ portfoliosData, portfoliosLoading }) => {
                   <img
                     loading="lazy"
                     decoding="async"
-                    src={portfolio.image}
+                    src={ASSETS_PATH + portfolio.image}
                     alt={portfolio.title}
                   />
                   <span className="overlay" />


### PR DESCRIPTION
🐛 fix([slug].jsx): update image source to use ASSETS_PATH variable for better flexibility and configurability
🐛 fix(RenderPortfolios.js): update image source to use ASSETS_PATH variable for better flexibility and configurability